### PR TITLE
Add claude-elixir-phoenix under new AI Coding Assistants and Skills section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ Development tools, LLM evaluation, and other utilities.
 
 ### Notebooks
 
-- [Talking to OpenAI real-time with boombox](https://github.com/membraneframework/boombox/blob/master/boombox_examples_data/talk_to_llm.html)
+- [Talking to OpenAI real-time with boombox](https://github.com/membraneframework/boombox/blob/master/examples/data/talk_to_llm.html)
 
 ### Videos
 

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ I'm a big fan of Elixir (as a MLE/Data Scientist). This is a list of resources t
 - [Model Serving and Inference](#model-serving-and-inference)
 - [Vector Databases and RAG](#vector-databases-and-rag)
 - [MCP and Integrations](#mcp-and-integrations)
+- [AI Coding Assistants and Skills](#ai-coding-assistants-and-skills)
 - [Evaluation and Utilities](#evaluation-and-utilities)
 - [Audio and Speech](#audio-and-speech)
 - [Resources](#resources)
@@ -98,6 +99,12 @@ Model Context Protocol servers and IDE/tool integrations.
 - [MCP Hex Server](https://hex-mcp.9elements.com/) - A MCP server for Elixir Hex packages.
 - [Phantom MCP](https://github.com/dbernheisel/phantom_mcp) - An MCP server framework for Elixir Plug with Phoenix integration and stdio support for clients like Claude Desktop.
 - [Tidewave Phoenix](https://github.com/tidewave-ai/tidewave_phoenix) - Tidewave for Phoenix, introspection/integration of a phoenix web app for AI coding tools over MCP.
+
+## AI Coding Assistants and Skills
+
+Plugins, skills, and agent configurations for AI coding tools targeting Elixir/Phoenix development.
+
+- [claude-elixir-phoenix](https://github.com/oliver-kriska/claude-elixir-phoenix) - Claude Code plugin for Elixir/Phoenix that orchestrates specialist agents for planning, implementation, and review, with auto-loading skills for LiveView, Ecto, OTP, and Tidewave MCP integration.
 
 ## Evaluation and Utilities
 


### PR DESCRIPTION
## Summary

- Adds [claude-elixir-phoenix](https://github.com/oliver-kriska/claude-elixir-phoenix) — a Claude Code plugin that orchestrates specialist AI agents for Elixir/Phoenix work, with auto-loading skills and Tidewave MCP integration.
- Introduces a new **AI Coding Assistants and Skills** section to house this and similar entries (Claude Code plugins, skills bundles, agent configurations targeting Elixir/Phoenix).
- Updates the table of contents with the new section.

The entry doesn't fit neatly into existing sections (it's a coding-assistant plugin rather than an LLM client, agent framework, or MCP server), so a dedicated section keeps the taxonomy clean and makes room for future additions in this fast-growing category.

## Test plan

- [x] `npx awesome-lint readme.md` produces no new warnings/errors from this change (pre-existing warnings about `Langchain`/`postgres`/`sqlite` casing are unrelated).
- [x] Maintainer to confirm the section name and placement fit the list's taxonomy.

---
_Generated by [Claude Code](https://claude.ai/code/session_015vUcZY3tNbbkBT7N6wiA1Y)_